### PR TITLE
clarify particle radius in warp

### DIFF
--- a/walkthroughs/EMPIAR-10164/relion.md
+++ b/walkthroughs/EMPIAR-10164/relion.md
@@ -41,6 +41,10 @@ We can now use the generated `.star` file to reconstruct subtomograms from our t
 ```{note}
 We reconstruct at a box twice as large as before because we have halved the pixel spacing.
 ```
+
+```{note}
+Note that the `particle diameter` is used to generate a normalization mask, and does *not* affect the size of the box. Here we choose a size that encompasses only the central hexamer, since that's the part we are interested in.
+```
 ````
 
 ```{image} relion.assets/subtomo-reconstruction.png


### PR DESCRIPTION
Added a simple note to clarify the meaning of `particle radius` in warp subtomogram reconstruction.