### PR TITLE
Update tilt-series-to-tomograms.md

### DIFF
--- a/walkthroughs/EMPIAR-10164/tilt-series-to-tomograms.md
+++ b/walkthroughs/EMPIAR-10164/tilt-series-to-tomograms.md
@@ -127,7 +127,7 @@ Starting with coarse pixel sizes significantly increases your ability to quickly
 ```
 ````
 
-We have to define the reconstruction area by setting the `Unbinned tomogram dimensions`. These are the dimensions that the tomogram would have if reconstructed at the pixel size of the tilt-series. To capture the full extent of the imaged area, we should use 4000 x 4000 for the x and y dimensions (because we downsampled our original ~8000x8000 super-resolution pixels by a factor of two). In z, we want the reconstruction to be large enough to include the entire imaged sample. In this case, 3000 $px$ is more than enough.
+We have to define the reconstruction area by setting the `Unbinned tomogram dimensions`. These are the dimensions that the tomogram would have if reconstructed at the pixel size of the tilt-series. To capture the full extent of the imaged area, we should use 7420 x 7676 for the x and y dimensions. In z, we want the reconstruction to be large enough to include the entire imaged sample. In this case, 3000 $px$ is more than enough.
 
 We can then click on `reconstruct full tomograms` at the top of the `Overview` tab to open the reconstruction dialog box.
 

--- a/walkthroughs/EMPIAR-10164/tilt-series-to-tomograms.md
+++ b/walkthroughs/EMPIAR-10164/tilt-series-to-tomograms.md
@@ -127,7 +127,7 @@ Starting with coarse pixel sizes significantly increases your ability to quickly
 ```
 ````
 
-We have to define the reconstruction area by setting the `Unbinned tomogram dimensions`. These are the dimensions that the tomogram would have if reconstructed at the pixel size of the tilt-series. To capture the full extent of the imaged area, we should use 7420 x 7676 for the x and y dimensions. In z, we want the reconstruction to be large enough to include the entire imaged sample. In this case, 3000 $px$ is more than enough.
+We have to define the reconstruction area by setting the `Unbinned tomogram dimensions`. These are the dimensions that the tomogram would have if reconstructed at the pixel size of the unbinned tilt images. To capture the full extent of the imaged area, we should use 8000 x 8000 for the x and y dimensions. In z, we want the reconstruction to be large enough to include the entire imaged sample. In this case, 6000 $px$ is more than enough.
 
 We can then click on `reconstruct full tomograms` at the top of the `Overview` tab to open the reconstruction dialog box.
 


### PR DESCRIPTION
Using 4000 X 4000 dimensions for x and y in WARP (version 1.0.9) truncates the reconstruction. Use the original unbinned dimensions instead.